### PR TITLE
Closes: #5 - Attendee create account with name

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  before_action :attendee_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def attendee_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+  end
 end

--- a/app/models/attendee.rb
+++ b/app/models/attendee.rb
@@ -3,4 +3,6 @@ class Attendee < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  validates :name, presence: true
 end

--- a/app/views/attendees/registrations/new.html.erb
+++ b/app/views/attendees/registrations/new.html.erb
@@ -27,7 +27,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Sign up" %>
+    <%= f.submit I18n.t('actions.sign_up') %>
   </div>
 <% end %>
 

--- a/app/views/attendees/registrations/new.html.erb
+++ b/app/views/attendees/registrations/new.html.erb
@@ -4,6 +4,11 @@
   <%= render "attendees/shared/error_messages", resource: resource %>
 
   <div class="field">
+    <%= f.label :name %><br />
+    <%= f.text_field :name, autofocus: true, autocomplete: "name" %>
+  </div>
+
+  <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -244,7 +244,7 @@ Devise.setup do |config|
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
   # are using only default views.
-  config.scoped_views = false
+  config.scoped_views = true
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).

--- a/config/locales/attendee.pt-BR.yml
+++ b/config/locales/attendee.pt-BR.yml
@@ -1,0 +1,9 @@
+---
+pt-BR:
+  activerecord:
+    attributes:
+      attendee:
+        name: 'Nome'
+        email: 'Email'
+        password: 'Senha'
+        password_confirmation: 'Confirmar senha'

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,6 +1,14 @@
 ---
 pt-BR:
+  actions:
+    sign_up: 'Cadastrar-se'
   activerecord:
+    attributes:
+      attendee:
+        name: 'Nome'
+        email: 'Email'
+        password: 'Senha'
+        password_confirmation: 'Confirmar senha'
     errors:
       messages:
         record_invalid: 'A validação falhou: %{errors}'
@@ -17,7 +25,7 @@ pt-BR:
     - sex
     - sáb
     abbr_month_names:
-    - 
+    -
     - jan
     - fev
     - mar
@@ -43,7 +51,7 @@ pt-BR:
       long: "%d de %B de %Y"
       short: "%d de %B"
     month_names:
-    - 
+    -
     - janeiro
     - fevereiro
     - março

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -3,12 +3,6 @@ pt-BR:
   actions:
     sign_up: 'Cadastrar-se'
   activerecord:
-    attributes:
-      attendee:
-        name: 'Nome'
-        email: 'Email'
-        password: 'Senha'
-        password_confirmation: 'Confirmar senha'
     errors:
       messages:
         record_invalid: 'A validação falhou: %{errors}'

--- a/db/migrate/20201018003854_add_name_to_attendees.rb
+++ b/db/migrate/20201018003854_add_name_to_attendees.rb
@@ -1,0 +1,5 @@
+class AddNameToAttendees < ActiveRecord::Migration[6.0]
+  def change
+    add_column :attendees, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_15_234119) do
+ActiveRecord::Schema.define(version: 2020_10_18_003854) do
 
   create_table "attendees", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2020_10_15_234119) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "name"
     t.index ["email"], name: "index_attendees_on_email", unique: true
     t.index ["reset_password_token"], name: "index_attendees_on_reset_password_token", unique: true
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,7 +31,7 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
-  
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
@@ -62,6 +62,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include Capybara::DSL
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/requests/attendee/registrations_spec.rb
+++ b/spec/requests/attendee/registrations_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'attendee /devise/registrations' do
+  describe 'request new_attendee_registration' do
+    context 'when has valid params' do
+      before do
+        visit new_attendee_registration_path
+
+        fill_in I18n.t('activerecord.attributes.attendee.name'),
+                with: 'new user'
+        fill_in I18n.t('activerecord.attributes.attendee.email'),
+                with: 'user@example.com'
+        fill_in I18n.t('activerecord.attributes.attendee.password'),
+                with: 'pass123'
+        fill_in I18n.t('activerecord.attributes.attendee.password_confirmation'),
+                with: 'pass123'
+
+        click_button I18n.t('actions.sign_up')
+      end
+
+      it 'record new attendee correctly', :aggregate_failures do
+        expect(Attendee.last.attributes).to include(
+          { name: 'new user',
+            email: 'user@example.com' }.stringify_keys
+        )
+      end
+
+      it 'redirect to "/"', :aggregate_failures do
+        expect(page).to have_current_path('/')
+        expect(page)
+          .to have_content I18n.t('devise.registrations.signed_up')
+      end
+    end
+
+    context 'when has invalid params' do
+      before do
+        visit new_attendee_registration_path
+
+        fill_in I18n.t('activerecord.attributes.attendee.name'),
+                with: nil
+        fill_in I18n.t('activerecord.attributes.attendee.email'),
+                with: nil
+        fill_in I18n.t('activerecord.attributes.attendee.password'),
+                with: nil
+        fill_in I18n.t('activerecord.attributes.attendee.password_confirmation'),
+                with: nil
+
+        click_button I18n.t('actions.sign_up')
+      end
+
+      it 'don\'t record new attendee' do
+        expect(Attendee.count).to eq 0
+      end
+
+      it 'redirect page to "/attendees"', :aggregate_failures do
+        expect(page).to have_current_path('/attendees')
+        expect(page)
+          .to_not have_content I18n.t('devise.registrations.signed_up')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Descrição
Necessário atribuição de campo `:name` para criação de conta de participante (`attendee`)

## CHANGELOG
- Configurado em `initializers/devise.rb` a configuração: `scoped_views = true`, permitindo modificação de views do devise.
- Adicionado migration para inclusão do campo `name` em `attendees`
- Modificado view `attendees/registrations/new.html.erb` para inclusão do campo `name`
- Adicionado validação do campo `name` no model `Attendee`
- Permitido em `application_controller.rb` a atribuição do campo name para devise.

## Issue resolvida
Closes #5 


