### PR TITLE
WIP: Administrator torna Workshop disponível

### DIFF
--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -16,6 +16,13 @@ class WorkshopsController < ApplicationController
     @workshop = Workshop.find(params[:id])
   end
 
+  # PATCH /workshops/:id/activate
+  def activate
+    workshop = Workshop.find(params[:id])
+    workshop.active!
+    redirect_to workshop, notice: 'Workshop atualizado com sucesso'
+  end
+
   private
 
   def workshop_params

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -1,5 +1,5 @@
 class WorkshopsController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: :show
   # GET
   def new
   end
@@ -14,6 +14,9 @@ class WorkshopsController < ApplicationController
   # GET /workshops/:id
   def show
     @workshop = Workshop.find(params[:id])
+		if !user_signed_in? && @workshop.draft?
+			redirect_to root_path, notice: 'Este workshop está indisponível'
+		end
   end
 
   # PATCH /workshops/:id/activate

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -8,3 +8,4 @@ class Workshop < ApplicationRecord
     I18n.t("activerecord.attributes.#{model_name.i18n_key}.status.#{status}")
   end
 end
+

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -1,4 +1,10 @@
 class Workshop < ApplicationRecord
   validates :name, :short_description, :full_description, :duration,
             :attendees, :workshop_date, :start_time, presence: true
+
+	enum status: { draft: 0, active: 1, inactive: 2 }
+
+  def human_status
+    I18n.t("activerecord.attributes.#{model_name.i18n_key}.status.#{status}")
+  end
 end

--- a/app/views/workshops/show.html.erb
+++ b/app/views/workshops/show.html.erb
@@ -10,4 +10,6 @@
   <dd><%= I18n.localize @workshop.workshop_date %></dd>
   <dt>Hora</dt>
   <dd><%= l @workshop.start_time, format: :short %></dd>
+  <dt>Status</dt>
+  <dd><%= @workshop.human_status %></dd>
 </dl>

--- a/app/views/workshops/show.html.erb
+++ b/app/views/workshops/show.html.erb
@@ -13,3 +13,13 @@
   <dt>Status</dt>
   <dd><%= @workshop.human_status %></dd>
 </dl>
+
+<div id='event_status'>
+	<% if @workshop.draft? %>
+		<div>
+			<%= button_to 'Tornar Workshop Disponível', activate_workshop_path(@workshop), method: :patch %>
+		</div>
+	<% end %>
+</div>
+
+

--- a/config/locales/models_pt-BR.yml
+++ b/config/locales/models_pt-BR.yml
@@ -1,0 +1,7 @@
+pt-BR:
+  activerecord:
+    attributes:
+      workshop:
+        status:
+          draft: 'Rascunho'
+

--- a/config/locales/models_pt-BR.yml
+++ b/config/locales/models_pt-BR.yml
@@ -3,5 +3,6 @@ pt-BR:
     attributes:
       workshop:
         status:
+          active: 'Ativo'
           draft: 'Rascunho'
 

--- a/config/locales/models_pt-BR.yml
+++ b/config/locales/models_pt-BR.yml
@@ -5,4 +5,5 @@ pt-BR:
         status:
           active: 'Ativo'
           draft: 'Rascunho'
+          inactive: 'Inativo'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,7 @@ Rails.application.routes.draw do
   devise_for :attendees
   devise_for :users
   root to: 'home#index'
-  resources :workshops, only: [ :new, :create, :show ]
+  resources :workshops, only: [ :new, :create, :show ] do
+    member { patch :activate }
+  end
 end

--- a/db/migrate/20201017220100_add_status_to_workshops.rb
+++ b/db/migrate/20201017220100_add_status_to_workshops.rb
@@ -1,0 +1,5 @@
+class AddStatusToWorkshops < ActiveRecord::Migration[6.0]
+  def change
+    add_column :workshops, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_15_234119) do
+ActiveRecord::Schema.define(version: 2020_10_17_220100) do
 
   create_table "attendees", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 2020_10_15_234119) do
     t.datetime "updated_at", precision: 6, null: false
     t.date "workshop_date"
     t.time "start_time"
+    t.integer "status", default: 0
   end
 
   add_foreign_key "enrollments", "attendees"

--- a/spec/features/admin_makes_workshop_available_spec.rb
+++ b/spec/features/admin_makes_workshop_available_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+feature 'Admin makes workshop available for enrollment' do
+	scenario 'successfully' do
+		# Arrange
+		user = User.create!(email: 'user@ruby.com.br', password: '12345678')
+		workshop = Workshop.create!(
+			name: 'Tutorial Ruby',
+			short_description: 'Tutorial básico Ruby',
+			full_description: 'Tutorial básico Ruby para iniciantes',
+			duration: '120',
+			workshop_date: Date.today + 3,
+			start_time: '14:00',
+			attendees: 50
+		)
+
+		# Act
+		login_as user, scope: :user
+		visit workshop_path(workshop)
+		within '#event_status' do
+			click_on 'Tornar Workshop Disponível'
+		end
+
+		# Assert
+		expect(page).to have_content 'Workshop atualizado com sucesso'
+		expect(page).to have_content 'Ativo'
+		expect(page).not_to have_content 'Rascunho'
+		expect(page).not_to have_button 'Tornar Workshop Disponível'
+	end
+end
+

--- a/spec/features/admin_register_workshops_spec.rb
+++ b/spec/features/admin_register_workshops_spec.rb
@@ -29,6 +29,7 @@ feature 'Admin register workshop' do
     expect(page).to have_content '60 minutos'
     expect(page).to have_content '05/12/2020'
     expect(page).to have_css('dd', text: /^14:00$/ )
+    expect(page).to have_content 'Rascunho'
   end
 
   context 'must be signed in' do

--- a/spec/features/admin_views_workshop_spec.rb
+++ b/spec/features/admin_views_workshop_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+feature 'Admin views Workshop' do
+  context 'regardless of Workshop status' do
+    scenario 'when Workshop is a draft' do
+      # Arrange
+      user = User.create!(email: 'user@ruby.com.br', password: '12345678')
+      workshop = Workshop.create!(
+        name: 'Design Patterns com Ruby',
+        short_description: 'Utilizando Design Patterns com Ruby',
+        full_description: 'Utilizando Design Patterns com Ruby com exemplos do mundo real',
+        duration: '120',
+        workshop_date: Date.today + 5,
+        start_time: '14:00',
+        attendees: 20,
+        status: :draft
+      )
+
+      # Act
+      login_as user, scope: :user
+      visit workshop_path(workshop)
+
+      # Assert
+      expect(page).to have_content workshop.name
+      expect(page).to have_content 'Rascunho'
+    end
+
+    scenario 'when Workshop is active' do
+      # Arrange
+      user = User.create!(email: 'user@ruby.com.br', password: '12345678')
+      workshop = Workshop.create!(
+        name: 'Design Patterns com Ruby',
+        short_description: 'Utilizando Design Patterns com Ruby',
+        full_description: 'Utilizando Design Patterns com Ruby com exemplos do mundo real',
+        duration: '120',
+        workshop_date: Date.today + 5,
+        start_time: '14:00',
+        attendees: 20,
+        status: :active
+      )
+
+      # Act
+      login_as user, scope: :user
+      visit workshop_path(workshop)
+
+      # Assert
+      expect(page).to have_content workshop.name
+      expect(page).to have_content 'Ativo'
+    end
+
+    scenario 'when Workshop is inactive' do
+      # Arrange
+      user = User.create!(email: 'user@ruby.com.br', password: '12345678')
+      workshop = Workshop.create!(
+        name: 'Design Patterns com Ruby',
+        short_description: 'Utilizando Design Patterns com Ruby',
+        full_description: 'Utilizando Design Patterns com Ruby com exemplos do mundo real',
+        duration: '120',
+        workshop_date: Date.today + 5,
+        start_time: '14:00',
+        attendees: 20,
+        status: :inactive
+      )
+
+      # Act
+      login_as user, scope: :user
+      visit workshop_path(workshop)
+
+      # Assert
+      expect(page).to have_content workshop.name
+      expect(page).to have_content 'Inativo'
+    end
+  end
+end
+

--- a/spec/features/unlogged_user_views_workshop_spec.rb
+++ b/spec/features/unlogged_user_views_workshop_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+feature 'Unlogged user views Workshop' do
+  context 'when Workshop is active' do
+    scenario 'successfully' do
+      # Arrange
+      workshop = Workshop.create!(
+        name: 'RSpec em 10 minutos',
+        short_description: 'Aprenda RSpec em 10 minutos',
+        full_description: 'Tutorial de RSpec com funcionamento básico',
+        duration: '120',
+        workshop_date: Date.today + 5,
+        start_time: '16:00',
+        attendees: 20,
+        status: :active
+      )
+
+      # Act
+      visit workshop_path(workshop)
+
+      # Assert
+      expect(page).to have_content workshop.name
+      expect(page).to have_content workshop.full_description
+    end
+  end
+
+  context 'when Workshop is in draft state' do
+    scenario 'unlogged user gets redirected to home' do
+      # Arrange
+      workshop = Workshop.create!(
+        name: 'RSpec em 10 minutos',
+        short_description: 'Aprenda RSpec em 10 minutos',
+        full_description: 'Tutorial de RSpec com funcionamento básico',
+        duration: '120',
+        workshop_date: Date.today + 5,
+        start_time: '16:00',
+        attendees: 20
+      )
+
+      # Act
+      visit workshop_path(workshop)
+
+      # Assert
+      expect(page.current_path).to eq(root_path)
+      expect(page).to have_content('Este workshop está indisponível')
+    end
+  end
+end
+


### PR DESCRIPTION
## Descrição

Adiciona campo `status` para **Workshop**
**Workshops** criados possuem `status` inicial `rascunho`.
Permite a **Administrador** tornar um **Workshop** `ativo`
Permite a qualquer usuário visualizar um **Workshop** que não seja um rascunho.

Closes #2 

