### PR TITLE
Adicionando status para workshops

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ gem 'webpacker', '~> 4.0'
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'capybara'
+  gem 'factory_bot_rails', '~> 6.1'
+  gem 'ffaker', '~> 2.17'
   gem 'rspec-rails'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,15 +5,14 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.7.1'
 
-
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'devise'
 gem 'jbuilder', '~> 2.7'
+gem 'pg', '~> 1.2'
 gem 'puma', '~> 4.1'
 gem 'rails', '~> 6.0.3', '>= 6.0.3.4'
 gem 'sass-rails', '>= 6'
 gem 'shoulda-matchers', '~> 4.0'
-gem 'sqlite3', '~> 1.4'
 gem 'turbolinks', '~> 5'
 gem 'webpacker', '~> 4.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,12 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.4.4)
     erubi (1.9.0)
+    factory_bot (6.1.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.1.0)
+      factory_bot (~> 6.1.0)
+      railties (>= 5.0.0)
+    ffaker (2.17.0)
     ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -243,6 +249,8 @@ DEPENDENCIES
   byebug
   capybara
   devise
+  factory_bot_rails (~> 6.1)
+  ffaker (~> 2.17)
   jbuilder (~> 2.7)
   listen (~> 3.2)
   pg (~> 1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,6 +264,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
+  tzinfo-data
   webpacker (~> 4.0)
 
 RUBY VERSION

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 class Workshop < ApplicationRecord
+  STATUSES = %i[draft active inactive]
+
   validates :name, :short_description, :full_description, :duration,
-            :attendees, :workshop_date, :start_time, presence: true
+            :attendees, :workshop_date, :start_time, :status, presence: true
 
   scope :future, -> { where('workshop_date > ?', Time.zone.now) }
+
+  enum status: STATUSES
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,3 +1,4 @@
 <% if user_signed_in? %>
-  <%= link_to 'Registrar Workshop', new_workshop_path %>
+  <%= link_to t(".register_workshops"), new_workshop_path %>
+  <%= link_to t(".list_workshops"), workshops_path %>
 <% end %>

--- a/app/views/workshops/_form.html.erb
+++ b/app/views/workshops/_form.html.erb
@@ -1,0 +1,32 @@
+<%= form_with(model: workshop, local: true) do |f| %>
+  <div>
+    <%= f.label :name, 'Nome' %>
+    <%= f.text_field :name  %>
+  </div>
+  <div>
+    <%= f.label :short_description, 'Descrição Curta' %>
+    <%= f.text_field :short_description %>
+  </div>
+  <div>
+    <%= f.label :full_description, 'Descrição Completa' %>
+    <%= f.text_field :full_description %>
+  </div>
+  <div>
+    <%= f.label :attendees, 'Capacidade Máxima' %>
+    <%= f.text_field :attendees %>
+  </div>
+  <div>
+    <%= f.label :workshop_date, 'Data' %>
+    <%= f.date_field :workshop_date %>
+  </div>
+  <div>
+    <%= f.label :start_time, 'Hora' %>
+    <%= f.time_field :start_time %>
+  </div>
+  <div>
+    <%= f.label :duration, 'Duração' %>
+    <%= f.number_field :duration %>
+  </div>
+  <%= yield f %>
+  <%= f.submit form_action %>
+<% end %>

--- a/app/views/workshops/edit.html.erb
+++ b/app/views/workshops/edit.html.erb
@@ -1,0 +1,8 @@
+<h1><%= t('.title') %></h1>
+
+<%= render "form", workshop: @workshop, form_action: t(".submit") do |f| %>
+  <div>
+    <%= f.label :status %>
+    <%= f.select :status, Workshop::STATUSES.collect {|status| [I18n.t("workshops.status.#{status}"), status] }  %>
+  </div>
+<% end %>

--- a/app/views/workshops/index.html.erb
+++ b/app/views/workshops/index.html.erb
@@ -1,15 +1,25 @@
-<% @workshops.each do |workshop| %>
-  <h1><%= workshop.name %></h1>
-  <dl>
-    <dt><%= I18n.t 'activerecord.attributes.workshop.short_description' %></dt>
-    <dd><%= workshop.short_description %></dd>
-    <dt><%= I18n.t 'activerecord.attributes.workshop.duration' %></dt>
-    <dd><%= workshop.duration %> minutos</dd>
-    <dt><%= I18n.t 'activerecord.attributes.workshop.workshop_date' %></dt>
-    <dd><%= I18n.localize workshop.workshop_date %></dd>
-    <dt><%= I18n.t 'activerecord.attributes.workshop.start_time' %></dt>
-    <dd><%= l workshop.start_time, format: :short %></dd>
-    <dt><%= I18n.t 'activerecord.attributes.workshop.attendees' %></dt>
-    <dd><%= workshop.attendees %></dd>
-  </dl>
+<h1><%= t(".title") %></h1>
+
+<% if @workshops.any? %>
+
+  <% @workshops.each do |workshop| %>
+    <h1><%= workshop.name %></h1>
+    <dl>
+      <dt><%= I18n.t 'activerecord.attributes.workshop.short_description' %></dt>
+      <dd><%= workshop.short_description %></dd>
+      <dt><%= I18n.t 'activerecord.attributes.workshop.duration' %></dt>
+      <dd><%= workshop.duration %> minutos</dd>
+      <dt><%= I18n.t 'activerecord.attributes.workshop.workshop_date' %></dt>
+      <dd><%= I18n.localize workshop.workshop_date %></dd>
+      <dt><%= I18n.t 'activerecord.attributes.workshop.start_time' %></dt>
+      <dd><%= l workshop.start_time, format: :short %></dd>
+      <dt><%= I18n.t 'activerecord.attributes.workshop.attendees' %></dt>
+      <dd><%= workshop.attendees %></dd>
+      <dt><%= t(".table.action") %></dt>
+      <dd><%= link_to t('.edit'), edit_workshop_path(workshop) %></dd>
+    </dl>
+  <% end %>
+
+<% else %>
+  <p><%= t(".table.empty") %></p>
 <% end %>

--- a/app/views/workshops/new.html.erb
+++ b/app/views/workshops/new.html.erb
@@ -1,33 +1,3 @@
-<h1>Registrar Workshop</h1>
+<h1><%= t(".title") %></h1>
 
-<%= form_with(model: Workshop.new, local: true) do |f| %>
-  <div>
-    <%= f.label :name, 'Nome' %>
-    <%= f.text_field :name %>
-  </div>
-  <div>
-    <%= f.label :short_description, 'Descrição Curta' %>
-    <%= f.text_field :short_description %>
-  </div>
-  <div>
-    <%= f.label :full_description, 'Descrição Completa' %>
-    <%= f.text_field :full_description %>
-  </div>
-  <div>
-    <%= f.label :attendees, 'Capacidade Máxima' %>
-    <%= f.text_field :attendees %>
-  </div>
-  <div>
-    <%= f.label :workshop_date, 'Data' %>
-    <%= f.date_field :workshop_date %>
-  </div>
-  <div>
-    <%= f.label :start_time, 'Hora' %>
-    <%= f.time_field :start_time %>
-  </div>
-  <div>
-    <%= f.label :duration, 'Duração' %>
-    <%= f.number_field :duration %>
-  </div>
-  <%= f.submit 'Registrar' %>
-<% end %>
+<%= render "form", workshop: Workshop.new, form_action: t(".submit") %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,9 +2,9 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: <%= ENV.fetch("POSTGRES_USER") %>
-  password: <%= ENV.fetch("POSTGRES_PASSWORD") %>
-  host: <%= ENV.fetch("POSTGRES_HOST") %>
+  username: <%= ENV.fetch("POSTGRES_USER", "workshop") %>
+  password: <%= ENV.fetch("POSTGRES_PASSWORD", "workshop") %>
+  host: <%= ENV.fetch("POSTGRES_HOST", "localhost") %>
   timeout: 5000
 
 development:

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -3,3 +3,5 @@ I18n.available_locales = [:'pt-BR']
  
 # Set default locale to something other than :en
 I18n.default_locale = :'pt-BR'
+
+I18n.load_path += Dir[Rails.root.join('config', 'locales', '**/*.{rb,yml}')]

--- a/config/locales/home/pt-BR.yml
+++ b/config/locales/home/pt-BR.yml
@@ -1,0 +1,5 @@
+pt-BR:
+  home:
+    index:
+      register_workshops: 'Registrar Workshop'
+      list_workshops: 'Listar workshops'

--- a/config/locales/workshop/pt-BR.yml
+++ b/config/locales/workshop/pt-BR.yml
@@ -1,0 +1,29 @@
+pt-BR:
+  workshops:
+    status:
+      draft: 'Rascunho'
+      active: 'Ativo'
+      inactive: 'Inativo'
+
+    notices:
+      edit:
+        success: 'O workshop "%{name}" foi editado com sucesso'
+      show:
+        draft_workshop: 'Não é possível acessar esse workshop no momento'
+
+    index:
+      edit: 'Editar'
+      title: 'Workshop'
+      table:
+        name: 'Nome'
+        status: 'Status'
+        action: 'Ação'
+        empty: 'Não há workshops registrados'
+
+    edit:
+      title: 'Editar Workshop'
+      submit: 'Editar'
+
+    new:
+      title: 'Registrar Workshop'
+      submit: 'Registrar'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :attendees
   devise_for :users
   root to: 'home#index'
-  resources :workshops, only: [ :index, :new, :create, :show ]
+  resources :workshops, only: [ :index, :new, :create, :show, :edit, :index, :update]
 end

--- a/db/migrate/20201018002010_add_status_to_workshop.rb
+++ b/db/migrate/20201018002010_add_status_to_workshop.rb
@@ -1,0 +1,5 @@
+class AddStatusToWorkshop < ActiveRecord::Migration[6.0]
+  def change
+    add_column :workshops, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -68,6 +68,7 @@ ActiveRecord::Schema.define(version: 2020_10_18_003854) do
     t.datetime "updated_at", precision: 6, null: false
     t.date "workshop_date"
     t.time "start_time"
+    t.integer "status", default: 0
   end
 
   add_foreign_key "enrollments", "attendees"

--- a/spec/factories/attendee.rb
+++ b/spec/factories/attendee.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :attendee do
+    email { FFaker::Internet.email }
+    password { FFaker::Internet.password }
+  end
+end

--- a/spec/factories/attendee.rb
+++ b/spec/factories/attendee.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :attendee do
     email { FFaker::Internet.email }
     password { FFaker::Internet.password }
+    name { FFaker::Name.first_name }
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user do
+    email { FFaker::Internet.email }
+    password { FFaker::Internet.password }
+  end
+end

--- a/spec/factories/workshop.rb
+++ b/spec/factories/workshop.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :workshop do
+    name { "Meu Workshop" }
+    short_description  { FFaker::Lorem.sentence }
+    full_description { FFaker::Lorem.paragraph(10) }
+    attendees { 50 }
+    duration { 30 }
+    workshop_date { 10.days.from_now }
+    start_time { Time.now.to_s(:time) }
+  end
+end

--- a/spec/features/admin_updates_workshop_spec.rb
+++ b/spec/features/admin_updates_workshop_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+feature "Admin updates workshop" do
+  scenario "successfully" do
+    workshop = create(:workshop)
+    user = create(:user)
+
+    login_as user, scope: :user
+    visit root_path
+    click_on I18n.t('home.index.list_workshops')
+    click_on I18n.t('workshops.index.edit')
+    select I18n.t('workshops.status.active'), from: "workshop[status]"
+    click_on I18n.t('workshops.edit.submit')
+
+    expect(page).to have_content(I18n.t('workshops.notices.edit.success', name: workshop.name))
+  end
+
+  context 'must be signed in' do
+    scenario 'to view edit form' do
+      workshop = create(:workshop)
+
+      visit edit_workshop_path(workshop)
+
+      expect(current_path).to eq new_user_session_path
+    end
+  end
+end

--- a/spec/features/attendee_views_workshop_spec.rb
+++ b/spec/features/attendee_views_workshop_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+feature "Attendee views workshop" do
+  scenario "successfully" do
+    workshop = create(:workshop, status: :active)
+    attendee = create(:attendee)
+
+    login_as attendee
+    visit workshop_path(workshop)
+
+    expect(current_path).to eq(workshop_path(workshop))
+    expect(page).to have_content(workshop.name)
+  end
+
+  context "workshop must not be a draft" do
+    scenario "to be viewed" do
+      workshop = create(:workshop, status: :draft)
+      attendee = create(:attendee)
+  
+      login_as attendee
+      visit workshop_path(workshop)
+  
+      expect(current_path).to eq(root_path)
+      expect(page).to have_content(I18n.t("workshops.notices.show.draft"))
+    end
+  end
+end

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -11,5 +11,6 @@ RSpec.describe Workshop, type: :model do
     it { should validate_presence_of(:duration) }
     it { should validate_presence_of(:workshop_date) }
     it { should validate_presence_of(:start_time) }
+    it { should validate_presence_of(:status) }
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,6 +64,7 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include Capybara::DSL
+  config.include FactoryBot::Syntax::Methods
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
## Descrição
<!--- Descreva suas alterações em detalhe -->
O `Workshop` foi alterado para possuir uma nova coluna `status`.  Por padrão um workshop é criado com o status `draft`. Não é possível alterar o status na criação do workshop (seguindo a premissa da issue, onde um workshop sempre é criado como rascunho), mas é possível editar o status após a sua criação.

O `WorkshopsController#show` pode ser visualizado por um `Attendee` contando que o status do workshop não seja `draft`

O formulário presente em `app/views/workshops/new.html.erb` foi movido para uma partial para que pudesse ser reaproveitado

Foram adicionados 2 gems para facilitar os testes:
- FFaker: Para gerar dados falsos (eg: email, senhas, parágrafos, sentenças)
- FactoryBot (Rails): Facilitar a instanciação de objetos na preparação dos testes

Procurei utilizar o `I18n`, incluindo o caminho `config/locales/**/*.{.rb,.yml}` na busca de locais onde as traduções podem ser encontradas



## Issue resolvida
<!--- O que você quer resolver com esse Pull Request? -->
Com esse PR os administradores podem editar as informações de um workshop, como o seu status. O workshop também poderá ser visualizado por um `Attendee`, contanto que o status do workshop não seja `draft`.
<!--- Informe aqui a issue que você está resolvendo. -->
Closes #2 


